### PR TITLE
Support Next.js 13 app-dir with pagesInDir config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# vscode
+# IDEs
 .vscode
+.idea

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,0 +1,46 @@
+import nextTranslate from '../src/index'
+import fs from 'fs'
+
+jest.spyOn(fs, 'existsSync')
+jest.spyOn(fs, 'readdirSync')
+
+jest.mock(
+  '../i18n',
+  () => ({
+    locales: ['en'],
+    defaultLocale: 'en',
+    pagesInDir: 'src/app',
+    pages: {
+      '*': ['common'],
+    },
+  }),
+  { virtual: true }
+)
+
+describe('nextTranslate', () => {
+  describe('nextTranslate -> pagesInDir', () => {
+    test('uses app dir loader if pagesInDir points to app dir', () => {
+      fs.readdirSync.mockImplementationOnce(() => [])
+      fs.existsSync.mockImplementationOnce(() => true)
+
+      const config = nextTranslate({})
+
+      expect(config.webpack({})).toEqual(
+        expect.objectContaining({
+          module: {
+            rules: expect.arrayContaining([
+              expect.objectContaining({
+                use: expect.objectContaining({
+                  loader: 'next-translate-plugin/loader',
+                  options: expect.objectContaining({
+                    isAppDirNext13: true,
+                  }),
+                }),
+              }),
+            ]),
+          },
+        })
+      )
+    })
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,9 @@ import path from 'path'
 import type webpack from 'webpack'
 import type { NextConfig } from 'next'
 
-import { parseFile, getDefaultExport, hasStaticName, hasHOC } from './utils'
+import { getDefaultExport, hasHOC, hasStaticName, parseFile } from './utils'
 import { LoaderOptions } from './types'
-import type { NextI18nConfig, I18nConfig } from 'next-translate'
+import type { I18nConfig, NextI18nConfig } from 'next-translate'
 
 const test = /\.(tsx|ts|js|mjs|jsx)$/
 const appDirNext13 = ['app', 'src/app']
@@ -49,13 +49,11 @@ function nextTranslate(nextConfig: NextConfig = {}): NextConfig {
   }
 
   let hasGetInitialPropsOnAppJs = false
-  let isAppDirNext13 = false
 
   if (!pagesInDir) {
     for (const possiblePageDir of possiblePageDirs) {
       if (fs.existsSync(path.join(dir, possiblePageDir))) {
         pagesInDir = possiblePageDir
-        isAppDirNext13 = appDirNext13.includes(possiblePageDir)
         break
       }
     }
@@ -65,6 +63,8 @@ function nextTranslate(nextConfig: NextConfig = {}): NextConfig {
     // Pages folder not found, so we're not using the loader
     return nextConfigWithI18n
   }
+
+  const isAppDirNext13 = appDirNext13.includes(pagesInDir);
 
   const pagesPath = path.join(dir, pagesInDir)
   const app = fs.readdirSync(pagesPath).find((page) => page.startsWith('_app.'))


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Check if `pagesInDir` provided by the user is Next.js 13 app-dir and use templateAppDir loader instead of default one

**Context**

I use both Next.js 13 app-dir feature as well as  Next.js Api Routes inside `pages/api/*.ts`.

Without `pagesInDir` option, `next-translate-plugin@2.0.2` finds `pages` directory and assumes there is no Next.js 13 app dir, although I use `pages` dir only for api routes

I cannot use Next.js 13.2 app [Route Handler](https://nextjs.org/blog/next-13-2#custom-route-handlers) due to https://github.com/aralroca/next-translate-plugin/issues/11 , which means I am forced to use `pages/api` dir for API handlers

The approach I decided on is: when user passes custom `pagesInDir` that points to Next.js 13 app directory, we set `isAppDirNext13` to true that forces the use of `templateAppDir` loader