### PR TITLE
fix: use the symbol from the node when present

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -147,6 +147,9 @@ export function parseCode(format: string, code: string): ParsedFilePkg {
  * @returns Entity for more detailed analysis by the compiler
  */
 export function getSymbol(filePkg: ParsedFilePkg, node: ts.Node) {
+  if ((node as any).symbol) {
+    return (node as any).symbol
+  }
   const location = ts.isVariableDeclaration(node) ? node.name : node
   return filePkg.checker.getSymbolAtLocation(location)
 }
@@ -646,7 +649,11 @@ export function existLocalesFolderWithNamespaces(dir: string) {
   return existNamespaceFile
 }
 
-export function isInsideAppDir(path: string, appFolder: string, pagesFolder: string) {
+export function isInsideAppDir(
+  path: string,
+  appFolder: string,
+  pagesFolder: string
+) {
   const appIndex = path.indexOf(appFolder)
   const pagesIndex = path.indexOf(pagesFolder)
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
The function that gets the symbol for node. If we already have a symbol, we use it, otherwise we try to get the symbol as before.

**Which issue (if any) does this pull request address?**
When there's a custom app (_app), the `getInitialProps` wasn't called.

**Is there anything you'd like reviewers to focus on?**
I'm not familiar with the Typescript Compiler API, but the change seems reasonable. I tried the basic example from `next-ranslate` and seems to be working fine. 