### PR TITLE
Do not send i18n config to next config when app dir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ function nextTranslate(nextConfig: NextConfig = {}): NextConfig {
 
   return {
     // new next with app folder cannot have i18n config in next.config.js
-    ...(existPagesFolder ? nextConfigWithI18n : {}),
+    ...(existPagesFolder ? nextConfigWithI18n : nextConfig),
     webpack(conf: webpack.Configuration, options) {
       const config: webpack.Configuration =
         typeof nextConfig.webpack === 'function'


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
lastest next does not work with i18n confing in next config when using app directory - routing will not work
try https://github.com/aralroca/next-translate/tree/master/examples/with-app-directory with latest next and you will see

**Which issue (if any) does this pull request address?**
#75 
**Is there anything you'd like reviewers to focus on?**
