### PR TITLE
fix(utils): Load typescript files relative to process current working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 .idea
 
 .DS_Store
+coverage/

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "postinstall": "node ./postinstall-message.js"
   },
   "dependencies": {
-    "typescript": "4.5.2"
+    "typescript": "5.3.3"
   },
   "devDependencies": {
     "@babel/cli": "7.20.7",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -411,7 +411,7 @@ export function hasHOC(filePkg: ParsedFilePkg) {
   return false
 }
 
-export function isNotExportModifier(modifier: ts.Modifier) {
+export function isNotExportModifier(modifier: ts.ModifierLike) {
   const exportModifiers: ts.SyntaxKind[] = [
     ts.SyntaxKind.DefaultKeyword,
     ts.SyntaxKind.ExportKeyword,
@@ -454,7 +454,6 @@ export function interceptExport(
         // Turning the class export into a regular declaration
         return ts.factory.updateClassDeclaration(
           node,
-          node.decorators,
           node.modifiers?.filter(isNotExportModifier),
           node.name ?? ts.factory.createIdentifier(defaultLocalName),
           node.typeParameters,
@@ -470,7 +469,6 @@ export function interceptExport(
         // Turning the function export into a regular declaration
         return ts.factory.updateFunctionDeclaration(
           node,
-          node.decorators,
           node.modifiers?.filter(isNotExportModifier),
           node.asteriskToken,
           node.name ?? ts.factory.createIdentifier(defaultLocalName),
@@ -514,7 +512,6 @@ export function interceptExport(
           finalLocalName = defaultLocalName
           extraImport = ts.factory.createImportDeclaration(
             undefined,
-            undefined,
             ts.factory.createImportClause(
               node.isTypeOnly,
               undefined,
@@ -537,7 +534,6 @@ export function interceptExport(
         // Remove target export specifier
         return ts.factory.updateExportDeclaration(
           node,
-          node.decorators,
           node.modifiers,
           node.isTypeOnly,
           ts.factory.updateNamedExports(node.exportClause, filteredSpecifiers),
@@ -570,7 +566,8 @@ export function interceptExport(
 
       return ts.visitEachChild(node, visitor, context)
     }
-    return ts.visitNode(sourceFile, visitor)
+
+    return ts.visitEachChild(sourceFile, visitor, context)
   })
 
   if (extraImport) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,9 +116,19 @@ export function getFilePkg(program: ts.Program, filename: string) {
  * @returns File package for further manipulations
  */
 export function parseFile(basePath: string, filename: string): ParsedFilePkg {
+  /**
+   * Parameter `filename` is the filepath relative to `basePath`, but the Program
+   * created by `ts.createProgram` will be relative to `process.cwd()`.
+   *
+   * We have to modify `filename` and make sure it is relative to `
+   * process.cwd`, otherwise `program.getSourceFile` in `getFilePkg` will return undefined
+   */
+  const cwd = process.cwd()
+  const filenameRelativeCWD = path.relative(cwd, path.join(basePath, filename))
+
   const options = getTsCompilerOptions(basePath, true)
-  const program = ts.createProgram([filename], options)
-  return getFilePkg(program, filename)
+  const program = ts.createProgram([filenameRelativeCWD], options)
+  return getFilePkg(program, filenameRelativeCWD)
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4621,10 +4621,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
-  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
+typescript@5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
+  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

**What changes did you make? (Give an overview)**

I've been having problems with this plugin due to the folder structure of my project and `NEXT_TRANSLATE_PATH` not being respected by `ts.createProgram()`. This change makes sure that the typescript `Program` created can access the source files correctly and does not return `undefined`. 

It might also be a good idea to throw an error/warning if `program.getSourceFile()` returns undefined, altering the user of the issue. I've been trying to track down the cause of an issue similar to https://github.com/aralroca/next-translate/issues/1040 (different root cause) and it's been a nightmare trying to debug it without having any information available on whatever or not the plugin was working correctly.

I'd recommend merging https://github.com/aralroca/next-translate-plugin/pull/78 first
