### PR TITLE
fix(BREAKING-CHANGE): remove support migration from pages to app router

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,16 +37,6 @@ function nextTranslate(nextConfig: NextConfig = {}): NextConfig {
     revalidate = 0,
   } = require(path.join(basePath, 'i18n')) as I18nConfig
 
-  let nextConfigWithI18n: NextConfig = {
-    ...nextConfig,
-    i18n: {
-      locales,
-      defaultLocale,
-      domains,
-      localeDetection,
-    },
-  }
-
   const pagesFolder = calculatePageDir('pages', pagesInDir, basePath)
   const appFolder = calculatePageDir('app', pagesInDir, basePath)
   const existLocalesFolder = existLocalesFolderWithNamespaces(basePath)
@@ -56,7 +46,7 @@ function nextTranslate(nextConfig: NextConfig = {}): NextConfig {
 
   // Pages folder not found, so we're not using the loader
   if (!existPagesFolder && !existPages(basePath, appFolder)) {
-    return nextConfigWithI18n
+    return nextConfig
   }
 
   if (existPagesFolder) {
@@ -80,6 +70,16 @@ function nextTranslate(nextConfig: NextConfig = {}): NextConfig {
         hasGetInitialPropsOnAppJs = isGetInitialProps || hasHOC(appPkg)
       }
     }
+  }
+
+  let nextConfigWithI18n: NextConfig = hasAppJs ? nextConfig : {
+    ...nextConfig,
+    i18n: {
+      locales,
+      defaultLocale,
+      domains,
+      localeDetection,
+    },
   }
 
   return {


### PR DESCRIPTION
Fixes https://github.com/aralroca/next-translate/issues/1166

Introducing that people could partially migrate from pages to app router was a bad idea because Next.js does not support it. Just introducing i18n in the configuration breaks the app router, I'm sorry to say, but the only way to fix it from the library is to remove the migration support, then pages and app router work, but it will no longer work to use both at the same time.