### PR TITLE
param is always accessed with promise in app-dir

### DIFF
--- a/src/templateAppDir.ts
+++ b/src/templateAppDir.ts
@@ -99,7 +99,7 @@ function templateRSCPage({
   ${code}
 
   export default async function __Next_Translate_new__${hash}__(props) {
-    const params = props.params instanceof Promise ? await props.params : props.params
+    const params = await props.params
     const searchParams = props.searchParams instanceof Promise ? await props.searchParams : props.searchParams
     const detectedLang = params?.lang ?? searchParams?.lang
 


### PR DESCRIPTION
This check doesn't work as expected and cause a issues with next-js 14. i.e
```
export default async function __Next_Translate_new__197f0ebfc2e__(props) {
 const detectedLang = await props.params?.lang ?? props.searchParams?.lang
                                       ^

 if (detectedLang === 'favicon.ico') return <RootLayout {...props} />
```

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Always access param using promise
**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
