### PR TITLE
fix: dynamicPathname becomes empty string on root route, breaking namespace loading

### DIFF
--- a/__tests__/__snapshots__/templateAppDir.test.js.snap
+++ b/__tests__/__snapshots__/templateAppDir.test.js.snap
@@ -22,7 +22,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <Error {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -86,7 +86,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <Error {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -150,7 +150,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <Error {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -214,7 +214,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <Error {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -278,7 +278,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <GlobalError {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -342,7 +342,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <GlobalError {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -406,7 +406,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <GlobalError {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -470,7 +470,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <GlobalError {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -534,7 +534,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <Layout {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -598,7 +598,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <Layout {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -662,7 +662,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <Layout {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -726,7 +726,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <Layout {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -790,7 +790,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <Loading {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -854,7 +854,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <Loading {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -918,7 +918,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <Loading {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -982,7 +982,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <Loading {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1046,7 +1046,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <NotFound {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1110,7 +1110,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <NotFound {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1174,7 +1174,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <NotFound {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1238,7 +1238,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
   if (globalThis.__NEXT_TRANSLATE__ && !detectedLang)
     return <NotFound {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1300,7 +1300,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1362,7 +1362,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1424,7 +1424,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1486,7 +1486,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1548,7 +1548,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1610,7 +1610,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1672,7 +1672,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1734,7 +1734,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1795,7 +1795,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1856,7 +1856,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1917,7 +1917,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -1978,7 +1978,7 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -2085,7 +2085,7 @@ export default function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -2159,7 +2159,7 @@ export default function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -2233,7 +2233,7 @@ export default function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -2338,7 +2338,7 @@ export default function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/about/us/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -2407,7 +2407,7 @@ export default function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -2476,7 +2476,7 @@ export default function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\");
+  let dynamicPathname = \\"/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -2627,10 +2627,8 @@ export default function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/embed/[category-name]/[tool-name]/\\".replace(
-    /\\\\/$/,
-    \\"\\"
-  );
+  let dynamicPathname =
+    \\"/embed/[category-name]/[tool-name]/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);
@@ -2694,10 +2692,8 @@ export default async function __Next_Translate_new__88d9831a00__(props) {
 
   if (detectedLang === \\"favicon.ico\\") return <Page {...props} />;
 
-  let dynamicPathname = \\"/embed/[category-name]/[tool-name]/\\".replace(
-    /\\\\/$/,
-    \\"\\"
-  );
+  let dynamicPathname =
+    \\"/embed/[category-name]/[tool-name]/\\".replace(/\\\\/$/, \\"\\") || \\"/\\";
   Object.keys(params ?? {}).forEach(function (k) {
     if (k !== \\"lang\\")
       dynamicPathname = dynamicPathname.replace(\\"[\\" + k + \\"]\\", params[k]);

--- a/src/templateAppDir.ts
+++ b/src/templateAppDir.ts
@@ -129,7 +129,7 @@ function templateRSCPage({
         : ''
     }
 
-    let dynamicPathname = '${pathname}'.replace(/\\/$/, '')
+    let dynamicPathname = '${pathname}'.replace(/\\/$/, '') || '/'
     Object.keys(params ?? {}).forEach(function(k) {
       if (k !== 'lang') dynamicPathname = dynamicPathname.replace('[' + k + ']', params[k])
     });
@@ -201,7 +201,7 @@ function templateRCCPage({
         : ''
     }
 
-    let dynamicPathname = '${pathname}'.replace(/\\/$/, '')
+    let dynamicPathname = '${pathname}'.replace(/\\/$/, '') || '/'
     Object.keys(params ?? {}).forEach(function(k) {
       if (k !== 'lang') dynamicPathname = dynamicPathname.replace('[' + k + ']', params[k])
     });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

For the root layout/page (`/page`, `/layout`, `/not-found`), `templateRSCPage` and `templateRCCPage` produce `pathname = '/'`. At runtime the generated wrapper does:

```js
let dynamicPathname = '/'.replace(/\/$/, '')   // → ''
```
…leaving dynamicPathname as an empty string. loadNamespaces short-circuits on falsy pathname and returns {__lang} with no namespaces:

```js
if (!conf.pathname) {
  console.warn('🚨 [next-translate] You forgot to pass the "pathname" inside "loadNamespaces" configuration');
  return [2, { __lang: __lang }];
}
```
The root layout's AppDirI18nProvider then sets globalThis.__NEXT_TRANSLATE__ = { namespaces: {} }. After client-side navigation to a nested route, any "use client" layout that hits the globalThis.__NEXT_TRANSLATE__ && !detectedLang early-return (introduced for [#1090](https://github.com/inklusion-digital/student-app-frontend/issues/1090)) inherits the empty namespaces and renders raw namespace:key strings instead of translations.

The bug is visible in this repo's committed snapshots — see __tests__/__snapshots__/templateAppDir.test.js.snap, the should load translations in a layout pageNoExt: /layout entry contains '/'.replace(/\\/$/, '') which evaluates to '' at runtime.

The fix: append || '/' after the trailing-slash strip in both templates, so an empty result falls back to '/'. One character per template, no behavior change for non-root paths.
```js
-    let dynamicPathname = '${pathname}'.replace(/\\/$/, '')
+    let dynamicPathname = '${pathname}'.replace(/\\/$/, '') || '/'
```
Snapshots regenerated to match (40 snapshots updated — every snapshot that previously contained the bare .replace(/\\/$/, "") now has the || "/" suffix).

**Which issue (if any) does this pull request address?**
No existing tracker issue. Discovered while debugging translation regressions on a Next 15 + App Router app. The early-return short-circuit that exposes the symptom was added in [#1090](https://github.com/inklusion-digital/student-app-frontend/issues/1090), but the underlying empty-pathname bug is independent of that change.

**Is there anything you'd like reviewers to focus on?**
Nope