### PR TITLE
fix: resolve inherited tsconfig options

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,13 +72,14 @@ export function getTsCompilerOptions(
     options = { allowJs: true }
   } else {
     const readConfigFileResult = ts.readConfigFile(configPath, ts.sys.readFile)
-    const jsonConfig = readConfigFileResult.config
-    const convertResult = ts.convertCompilerOptionsFromJson(
-      jsonConfig.compilerOptions,
-      basePath
+    const parsedConfig = ts.parseJsonConfigFileContent(
+      readConfigFileResult.config,
+      ts.sys,
+      path.dirname(configPath)
     )
 
-    options = convertResult.options
+    options = parsedConfig.options
+
   }
 
   if (cutDependencies) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,7 +79,6 @@ export function getTsCompilerOptions(
     )
 
     options = parsedConfig.options
-
   }
 
   if (cutDependencies) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,7 +75,7 @@ export function getTsCompilerOptions(
     const parsedConfig = ts.parseJsonConfigFileContent(
       readConfigFileResult.config,
       ts.sys,
-      path.dirname(configPath)
+      basePath
     )
 
     options = parsedConfig.options


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Updated the TypeScript compiler options handling to properly resolve options inherited through `tsconfig.json`'s `extends`.

Previously, the plugin read `compilerOptions` directly from the root `tsconfig.json`, which meant options defined in an extended configuration were not picked up.

The implementation now uses TypeScript's `parseJsonConfigFileContent` to resolve the effective configuration, including inherited options.

**Which issue (if any) does this pull request address?**

This fixes an issue where TypeScript options inherited from a shared `tsconfig.json` were not properly recognized by the plugin.

For example, when `allowJs` was defined in an extended configuration, it was not detected unless it was also explicitly declared in the application's own `tsconfig.json`.

**Is there anything you'd like reviewers to focus on?**
Please focus on whether using `parseJsonConfigFileContent` is the appropriate way to resolve the effective TypeScript configuration while preserving the plugin's existing behavior.